### PR TITLE
Using any auth middleware

### DIFF
--- a/src/config/requirepin.php
+++ b/src/config/requirepin.php
@@ -84,4 +84,9 @@ return [
      * that is sent when a user's pin has been changed
      */
     'auth_guard' => 'web',
+    
+    /**
+     * sanctum/api - Route middleware of authenticated user
+     */
+    'auth_middleware' => 'sanctum',
 ];

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -3,7 +3,9 @@
 use Illuminate\Support\Facades\Route;
 use Ikechukwukalu\Requirepin\Controllers\PinController;
 
-Route::middleware('auth:sanctum')->group(function () {
+$authMiddleware = config('requiredpin.auth_middleware');
+
+Route::middleware('auth:'.$authMiddleware)->group(function () {
     Route::post('change/pin', [PinController::class, 'changePin'])
         ->name('changePin');
 


### PR DESCRIPTION
<!--
Thanks for contributing to this package! We only accept PR to the latest stable version.

If you're pushing a Feature:
- Title it: "Multiple Auth Middleware"
- This feature is handling for many middleware like `auth:sanctum` or `auth:api` (for ![sanctum](https://laravel.com/docs/11.x/sanctum#protecting-spa-routes) ![passport](https://laravel.com/docs/11.x/passport#via-middleware))
- Snippet:
```
$authMiddleware = config('requiredpin.auth_middleware');

Route::middleware('auth:'.$authMiddleware)->group(function () {
    Route::post('change/pin', [PinController::class, 'changePin'])
        ->name('changePin');
```
- Ensure it doesn't break backward compatibility.

If you're pushing a Fix:
- Title it: "[X.x] FIX: The bug name"
- Describe how it fixes in a few words.
- Ensure it doesn't break backward compatibility.

All Pull Requests run with extensive tests for stable and latest versions of PHP and Laravel. 
Ensure your tests pass or your PR may be taken down.
-->

# Description

This feature/fix allows to use custom auth middleware
This feature is handling for any middleware like `auth:sanctum` or `auth:api` (for [sanctum](https://laravel.com/docs/11.x/sanctum#protecting-spa-routes) or [passport](https://laravel.com/docs/11.x/passport#via-middleware)) or is this only support for sanctum @ikechukwukalu ?

# Code samples

```php
$authMiddleware = config('requiredpin.auth_middleware');

Route::middleware('auth:'.$authMiddleware)->group(function () {
    Route::post('change/pin', [PinController::class, 'changePin'])
        ->name('changePin');
    // ...
});
```
